### PR TITLE
bpf-map: print map flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Type:		Hash
 Key size:	4
 Value size:	104
 Max entries:	1024
+Flags:		0x0
 
 $ sudo bpf-map dump /sys/fs/bpf/tc/globals/cilium_lxc
 Key:

--- a/bpf-map.go
+++ b/bpf-map.go
@@ -88,6 +88,6 @@ func infoMap(ctx *cli.Context) {
 		os.Exit(1)
 	}
 
-	fmt.Printf("Type:\t\t%s\nKey size:\t%d\nValue size:\t%d\nMax entries:\t%d\n",
-		m.MapType.String(), m.KeySize, m.ValueSize, m.MaxEntries)
+	fmt.Printf("Type:\t\t%s\nKey size:\t%d\nValue size:\t%d\nMax entries:\t%d\nFlags:\t\t%#x\n",
+		m.MapType.String(), m.KeySize, m.ValueSize, m.MaxEntries, m.Flags)
 }


### PR DESCRIPTION
Show the bpf map flags in the info output.

Signed-off-by: Tobias Klauser <tklauser@distanz.ch>